### PR TITLE
use relative paths in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,108 +1,108 @@
 [submodule "libfm"]
 	path = libfm
-	url = git@git.lxde.org:/lxde/libfm.git
+	url = ./libfm.git
 	branch = master
 [submodule "menu-cache"]
 	path = menu-cache
-	url = git@git.lxde.org:/lxde/menu-cache.git
+	url = ./menu-cache.git
 	branch = master
 [submodule "liblxqt"]
 	path = liblxqt
-	url = git@git.lxde.org:/lxde/liblxqt.git
+	url = ./liblxqt.git
 	branch = master
 [submodule "libqtxdg"]
 	path = libqtxdg
-	url = git@git.lxde.org:/lxde/libqtxdg.git
+	url = ./libqtxdg.git
 	branch = master
 [submodule "lxqt-about"]
 	path = lxqt-about
-	url = git@git.lxde.org:/lxde/lxqt-about.git
+	url = ./lxqt-about.git
 	branch = master
 [submodule "lxqt-powermanagement"]
 	path = lxqt-powermanagement
-	url = git@git.lxde.org:/lxde/lxqt-powermanagement.git
+	url = ./lxqt-powermanagement.git
 	branch = master
 [submodule "pcmanfm-qt"]
 	path = pcmanfm-qt
-	url = git@git.lxde.org:/lxde/pcmanfm-qt.git
+	url = ./pcmanfm-qt.git
 	branch = master
 [submodule "libsysstat"]
 	path = libsysstat
-	url = git@git.lxde.org:/lxde/libsysstat.git
+	url = ./libsysstat.git
 	branch = master
 [submodule "liblxqt-mount"]
 	path = liblxqt-mount
-	url = git@git.lxde.org:/lxde/liblxqt-mount.git
+	url = ./liblxqt-mount.git
 	branch = master
 [submodule "lxqt-runner"]
 	path = lxqt-runner
-	url = git@git.lxde.org:/lxde/lxqt-runner.git
+	url = ./lxqt-runner.git
 	branch = master
 [submodule "lxqt-policykit"]
 	path = lxqt-policykit
-	url = git@git.lxde.org:/lxde/lxqt-policykit.git
+	url = ./lxqt-policykit.git
 	branch = master
 [submodule "lxqt-panel"]
 	path = lxqt-panel
-	url = git@git.lxde.org:/lxde/lxqt-panel.git
+	url = ./lxqt-panel.git
 	branch = master
 [submodule "lxqt-openssh-askpass"]
 	path = lxqt-openssh-askpass
-	url = git@git.lxde.org:/lxde/lxqt-openssh-askpass.git
+	url = ./lxqt-openssh-askpass.git
 	branch = master
 [submodule "lxqt-notificationd"]
 	path = lxqt-notificationd
-	url = git@git.lxde.org:/lxde/lxqt-notificationd.git
+	url = ./lxqt-notificationd.git
 	branch = master
 [submodule "lxqt-config"]
 	path = lxqt-config
-	url = git@git.lxde.org:/lxde/lxqt-config.git
+	url = ./lxqt-config.git
 	branch = master
 [submodule "lxqt-appswitcher"]
 	path = lxqt-appswitcher
-	url = git@git.lxde.org:/lxde/lxqt-appswitcher.git
+	url = ./lxqt-appswitcher.git
 	branch = master
 [submodule "obconf-qt"]
 	path = obconf-qt
-	url = git@git.lxde.org:/lxde/obconf-qt.git
+	url = ./obconf-qt.git
 	branch = master
 [submodule "lximage-qt"]
 	path = lximage-qt
-	url = git@git.lxde.org:/lxde/lximage-qt.git
+	url = ./lximage-qt.git
 	branch = master
 [submodule "lxqt-globalkeys"]
 	path = lxqt-globalkeys
-	url = git@git.lxde.org:/lxde/lxqt-globalkeys.git
+	url = ./lxqt-globalkeys.git
 	branch = master
 [submodule "lxqt-common"]
 	path = lxqt-common
-	url = git@git.lxde.org:/lxde/lxqt-common.git
+	url = ./lxqt-common.git
 	branch = master
 [submodule "lxqt-lightdm-greeter"]
 	path = lxqt-lightdm-greeter
-	url = git@git.lxde.org:/lxde/lxqt-lightdm-greeter.git
+	url = ./lxqt-lightdm-greeter.git
 	branch = master
 [submodule "compton-conf"]
 	path = compton-conf
-	url = git@git.lxde.org:/lxde/compton-conf.git
+	url = ./compton-conf.git
 	branch = master
 [submodule "lxmenu-data"]
 	path = lxmenu-data
-	url = git@git.lxde.org:/lxde/lxmenu-data.git
+	url = ./lxmenu-data.git
 	branch = master
 [submodule "lxqt-qtplugin"]
 	path = lxqt-qtplugin
-	url = git@git.lxde.org:/lxde/lxqt-qtplugin.git
+	url = ./lxqt-qtplugin.git
 	branch = master
 [submodule "lxqt-session"]
 	path = lxqt-session
-	url = git@git.lxde.org:/lxde/lxqt-session.git
+	url = ./lxqt-session.git
 [submodule "lxqt-config-randr"]
 	path = lxqt-config-randr
-	url = git@git.lxde.org:/lxde/lxqt-config-randr.git
+	url = ./lxqt-config-randr.git
 [submodule "lxqt-admin"]
 	path = lxqt-admin
-	url = git@git.lxde.org:/lxde/lxqt-admin.git
+	url = ./lxqt-admin.git
 [submodule "qtmimetypes"]
 	path = mimetypes
 	url = git@gitorious.org:qtplayground/mimetypes.git


### PR DESCRIPTION
This makes the lxde-qt super repo usable for people who have no
SSH pubkey deposited on git.lxde.org.
