### PR TITLE
Remove superfluous double-space in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -30,5 +30,5 @@
 * Distribution & Version: 
 * Kernel: 
 * Qt Version: 
-* liblxqt Version:  
+* liblxqt Version: 
 * Package version: 


### PR DESCRIPTION
Removes the presumably accidental double-space after "liblxqt Version:" towards the bottom of the issue template.

This has to be the most petty and unnecessary pull request I've ever done.