### PR TITLE
lxqt-build-tools has to be compiled in first place.

### DIFF
--- a/cmake_repos.list
+++ b/cmake_repos.list
@@ -1,6 +1,6 @@
 CMAKE_REPOS=" \
-	libqtxdg \
 	lxqt-build-tools \
+	libqtxdg \
 	liblxqt \
 	libsysstat \
 	libfm-qt \


### PR DESCRIPTION
lxqt-build-tools has to be compiled in first place. The other projects need this to be build.