### PR TITLE
Divide bugs from feature request, using new GH templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,38 +1,48 @@
 ---
 name: Bug report
-about: Create a report to help us improve
+about: Create a report to help us improve LXQt
 title: ''
 labels: ''
 assignees: ''
 
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+<!--- BEFORE FILLING OUT THIS REPORT FORM:                                 --->
+<!--- Dear users of stable and LTS (Long Term Service) distributions:      --->
+<!--- Please do NOT file bugs against outdated versions of LXQt            --->
+<!--- components, which such distributions likely use; instead, use your   --->
+<!--- distribution's bugtracker.                                           --->
 
-**To Reproduce**
-Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+<!--- Provide a general summary of the issue in the title above. You       --->
+<!--- should not delete relevant sections and/or questions in your report  --->
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+##### Expected Behavior
+<!--- Tell us what should happen                                            -->
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+##### Current Behavior
+<!--- Tell us what happens instead of the expected behaviour.               -->
 
-**Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+##### Possible Solution
+<!--- Not obligatory, but suggest a fix/reason for the bug.                --->
 
-**Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+##### Steps to Reproduce (for bugs)
+<!--- Provide a link to a live example, or an unambiguous set of steps to  --->
+<!--- reproduce this bug. Include code to reproduce, if relevant           --->
+1. 
+2. 
+3. 
+4. 
 
-**Additional context**
-Add any other context about the problem here.
+##### Context
+<!--- How has this issue affected you? What are you trying to accomplish?  --->
+<!--- Providing context helps us come up with a solution that is most      --->
+<!--- useful in the real world                                             --->
+
+##### System Information
+<!--- Include as many relevant details about the system you experienced    --->
+<!--- the bug in                                                           --->
+* Distribution & Version: 
+* Kernel: 
+* Qt Version: 
+* liblxqt Version: 
+* Package version: 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: GitHub Community Support
+    url: https://github.community/
+    about: Please ask and answer questions here.
+  - name: GitHub Security Bug Bounty
+    url: https://bounty.github.com/
+    about: Please report security vulnerabilities here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
-  - name: GitHub Community Support
-    url: https://github.community/
-    about: Please ask and answer questions here.
-  - name: GitHub Security Bug Bounty
-    url: https://bounty.github.com/
-    about: Please report security vulnerabilities here.
+  - name: LXQt Discussions
+    url: https://github.com/lxqt/lxqt/discussions/
+    about: For general questions, problems and else.
+  - name: Instant Messaging
+    url: https://lxqt-project.org/
+    about: For Matrix, Telegram and IRC see channel list on lxqt-project.org

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[Feature request]"
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,13 +8,20 @@ assignees: ''
 ---
 
 **Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+<!-- A clear and concise description of what the problem is.                -->
+<!-- Example: I'm always frustrated when [...]                              -->
 
 **Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+<!-- A clear and concise description of what you want to happen, tell us    -->
+<!-- how it should work, explain the difference from current behavior.      -->
+<!-- A screenshot might help.                                               -->
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+**Describe eventual alternatives you've considered**
+<!-- A clear and concise description of any alternative solutions or        -->
+<!-- features you've considered.                                            -->
 
-**Additional context**
-Add any other context or screenshots about the feature request here.
+##### Context
+<!-- How has this issue affected you? What are you trying to accomplish?    -->
+<!-- Providing context helps us come up with a solution that is most        -->
+<!-- useful in the real world                                               -->
+


### PR DESCRIPTION
A first draft, I separated some text from the old template and merged it with the default template for feature request.
There is the good option to add other links.
Preview here:
https://github.com/stefonarch/lxqt/issues/new/choose